### PR TITLE
fixing attested-tls out-of-proc docker image

### DIFF
--- a/containersamples/attested_tls/Dockerfile
+++ b/containersamples/attested_tls/Dockerfile
@@ -1,12 +1,17 @@
 FROM ubuntu:18.04 as oe-attested-tls
 
-ENV PSW_VERSION=2.11
-
+# This is the latest PSW version we are currently supporting. This may change in the future and you may require to update it
+# In that case, refer: https://01.org/intel-software-guard-extensions/downloads
+ENV PSW_VERSION=2.12
 RUN if [ -z "$PSW_VERSION" ]; then echo "Please set PSW_VERSION (e.g. 2.11)." >&2; exit 1; fi
-
 RUN apt-get update && apt-get install -y \
     wget \
-    gnupg
+    gnupg \
+    python \
+    apt-transport-https \
+    libssl1.0.0 \
+    make
+
 
 # Use the APT preference file to pin sgx packages to specific versions
 # Reference https://manpages.debian.org/buster/apt/apt_preferences.5.en.html
@@ -15,36 +20,37 @@ RUN apt-get update && apt-get install -y \
 RUN ["/bin/bash", "-c", "wget -r -l1 --no-parent -nd -A *sgx_$(echo ${PSW_VERSION//./_})_bionic_custom_version.cfg https://download.01.org/intel-sgx/sgx_repo/ubuntu/apt_preference_files/"]
 RUN ["/bin/bash", "-c", "mv *sgx_$(echo ${PSW_VERSION//./_})_bionic_custom_version.cfg /etc/apt/preferences.d/intel-sgx.pref"]
 
+
 # Add the repository to sources, and add the key to the list of
 # trusted keys used by the apt to authenticate packages
-## Adding the Intel and Microsoft repositories to apt
-RUN echo "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main" | tee /etc/apt/sources.list.d/intel-sgx.list \
+RUN echo 'deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main' | tee /etc/apt/sources.list.d/intel-sgx.list \
     && wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add -
+RUN echo "deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic-7 main" | tee /etc/apt/sources.list.d/llvm-toolchain-bionic-7.list \
+    && wget -qO - https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -
 RUN echo "deb [arch=amd64] https://packages.microsoft.com/ubuntu/18.04/prod bionic main" | tee /etc/apt/sources.list.d/msprod.list \
     && wget -qO - https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
 
+
 RUN apt-get update && apt-get install -y \
-    clang-7 \
-    libssl-dev \
-    gdb \
-    libprotobuf10 \
-    libsgx-dcap-ql \
-    libsgx-quote-ex \
-    az-dcap-client \
-    open-enclave \
-    git
+    clang-7 \ libssl-dev \ gdb \ libprotobuf10 \ libsgx-dcap-ql \
+    libsgx-quote-ex \ az-dcap-client \ open-enclave \ git \ libsgx-enclave-common \
+    libsgx-enclave-common-dev \ libsgx-dcap-ql-dev \ gcc \ g++ \ python-pip \
+    sgx-aesm-service \ ibsgx-aesm-quote-ex-plugin \ libsgx-urts \ libsgx-headers \
+    linux-base-sgx
 
-## Copy over the samples, Source openenclaverc, Set up environment variables, Make the attested-tls sample
+RUN pip install cmake
+
+## The following sets the flag for out of proc attestation mode. Alternatively you can set this flag on the kubernetes deployment files
+ENV SGX_AESM_ADDR=1
+
+## Copy over the samples, source openenclaverc, set up environment variables
 RUN cp -R /opt/openenclave/share/openenclave/samples . \
-&& . /opt/openenclave/share/openenclave/openenclaverc \ 
-&& cd samples/attested_tls \
-&& export CC=gcc && export CXX=g++ && export PKG_CONFIG_PATH=/opt/openenclave/share/pkgconfig/ \
-&& make
+    && . /opt/openenclave/share/openenclave/openenclaverc \
+    && cd /samples/attested_tls \
+    && export CC=gcc && export CXX=g++ && export PKG_CONFIG_PATH=/opt/openenclave/share/pkgconfig/ \
+    && mkdir build && cd build && cmake .. && make
 
-WORKDIR /opt/openenclave/share/openenclave/samples/attested_tls
+# Set the directory
+WORKDIR /samples/attested_tls/build
 
-## The following sets the flag for out of proc attestation mode. Alternatively you can set this flag on the deployment files
-ENV SGX_AESM_ADDR=1 
-
-## Set the command to run the attested-tls sample
-CMD make run-server-in-loop
+CMD make run 

--- a/containersamples/attested_tls/Dockerfile
+++ b/containersamples/attested_tls/Dockerfile
@@ -1,13 +1,12 @@
 FROM ubuntu:18.04 as oe-attested-tls
 
-# This is the latest PSW version we are currently supporting. This may change in the future and you may require to update it
-# In that case, refer: https://01.org/intel-software-guard-extensions/downloads
 ENV PSW_VERSION=2.11
+
 RUN if [ -z "$PSW_VERSION" ]; then echo "Please set PSW_VERSION (e.g. 2.11)." >&2; exit 1; fi
+
 RUN apt-get update && apt-get install -y \
     wget \
     gnupg
-
 
 # Use the APT preference file to pin sgx packages to specific versions
 # Reference https://manpages.debian.org/buster/apt/apt_preferences.5.en.html
@@ -16,15 +15,13 @@ RUN apt-get update && apt-get install -y \
 RUN ["/bin/bash", "-c", "wget -r -l1 --no-parent -nd -A *sgx_$(echo ${PSW_VERSION//./_})_bionic_custom_version.cfg https://download.01.org/intel-sgx/sgx_repo/ubuntu/apt_preference_files/"]
 RUN ["/bin/bash", "-c", "mv *sgx_$(echo ${PSW_VERSION//./_})_bionic_custom_version.cfg /etc/apt/preferences.d/intel-sgx.pref"]
 
-
 # Add the repository to sources, and add the key to the list of
 # trusted keys used by the apt to authenticate packages
+## Adding the Intel and Microsoft repositories to apt
 RUN echo "deb [arch=amd64] https://download.01.org/intel-sgx/sgx_repo/ubuntu bionic main" | tee /etc/apt/sources.list.d/intel-sgx.list \
     && wget -qO - https://download.01.org/intel-sgx/sgx_repo/ubuntu/intel-sgx-deb.key | apt-key add -
-# Add Microsoft repo for az-dcap-client
 RUN echo "deb [arch=amd64] https://packages.microsoft.com/ubuntu/18.04/prod bionic main" | tee /etc/apt/sources.list.d/msprod.list \
     && wget -qO - https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
-
 
 RUN apt-get update && apt-get install -y \
     clang-7 \
@@ -37,14 +34,17 @@ RUN apt-get update && apt-get install -y \
     open-enclave \
     git
 
-## The following sets the flag for out of proc attestation mode. Alternatively you can set this flag on the kubernetes deployment files
-ENV SGX_AESM_ADDR=1
-
-## Copy over the samples, source openenclaverc, set up environment variables
+## Copy over the samples, Source openenclaverc, Set up environment variables, Make the attested-tls sample
 RUN cp -R /opt/openenclave/share/openenclave/samples . \
-    && . /opt/openenclave/share/openenclave/openenclaverc \
-    && cd /samples/attested_tls \
-    && export CC=gcc && export CXX=g++ && export PKG_CONFIG_PATH=/opt/openenclave/share/pkgconfig/ \
-    && make 
+&& . /opt/openenclave/share/openenclave/openenclaverc \ 
+&& cd samples/attested_tls \
+&& export CC=gcc && export CXX=g++ && export PKG_CONFIG_PATH=/opt/openenclave/share/pkgconfig/ \
+&& make
 
+WORKDIR /opt/openenclave/share/openenclave/samples/attested_tls
+
+## The following sets the flag for out of proc attestation mode. Alternatively you can set this flag on the deployment files
+ENV SGX_AESM_ADDR=1 
+
+## Set the command to run the attested-tls sample
 CMD make run-server-in-loop


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->

previous attested-tls dockerfile was not working with latest openenclave sample's changes because it was missing certain dependencies and setup commands

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[ x ] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ x ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone https://github.com/Azure-Samples/confidential-computing
cd Azure-Samples/confidential-computing
git checkout angoring/testing
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
docker build .
```

## What to Check
Verify that the following are valid
have verified that this image successfully passes the tests in the aks-test-pipeline: https://dev.azure.com/openenclave/ACC-Services/_build/results?buildId=4118&view=logs&j=0dd09ce4-10b4-510e-f850-7aed9e89d5ac&t=deb8da88-103c-567e-b89c-3ce711c7dc15